### PR TITLE
fix(variables): pre-commit check to enforce variables in variables file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: mfinelli/setup-shfmt@v2
+      - name: Install actionlint
+        uses: open-turo/action-install-release@v1
+        with:
+          repository: rhysd/actionlint
+      - name: Pre-commit
+        uses: open-turo/action-pre-commit@v1
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: script/test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+      - test
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: script/test
+
   # Build job
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,3 @@
-######################
-# Yaml related hooks
-# These only have shell dependencies
 - id: vars-in-variables-files
   name: "Ensure that all variables are defined in files that have the following name format: `variables[.grouping].tf`"
   description: "Errors if a variable is defined in a file that does not start with `variables.`"
@@ -8,4 +5,11 @@
   language: script
   files: \.tf$
   exclude: ^variables\..*\.tf$
-  ######################
+
+- id: outputs-in-outputs-files
+  name: "Ensure that all outputs are defined in files that have the following name format: `outputs[.grouping].tf`"
+  description: "Errors if a outputs is defined in a file that does not start with `outputs.`"
+  entry: hooks/outputs-in-outputs-files/check
+  language: script
+  files: \.tf$
+  exclude: ^outputs\..*\.tf$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,11 @@
+######################
+# Yaml related hooks
+# These only have shell dependencies
+- id: vars-in-variables-files
+  name: "Ensure that all variables are defined in files that have the following name format: `variables[.grouping].tf`"
+  description: "Errors if a variable is defined in a file that does not start with `variables.`"
+  entry: hooks/vars-in-variables-files/check
+  language: script
+  files: \.tf$
+  exclude: ^variables\..*\.tf$
+  ######################

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,3 +18,62 @@ We use the following standards as a baseline for all Terraform code at Turo:
   formatting and linting standards.
 - Scripts to rule them all -- we use [scripts to rule them all](https://github.com/github/scripts-to-rule-them-all) to
   provide consistent usage and functionality across all repositories.
+
+## `pre-commit` configuration
+
+We expect that all tf repos will have the following pre-commit configuration:
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0 # Use the ref you want to point at
+    hooks:
+      - id: check-json
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/open-turo/standards-terraform
+    rev: add-pre-commit-hooks
+    hooks:
+      - id: vars-in-variables-files
+      - id: outputs-in-outputs-files
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.77.1
+    hooks:
+      - id: terraform_fmt
+        stages: [commit]
+      - id: terraform_validate
+        stages: [commit]
+      - id: terraform_docs
+        stages: [commit]
+      - id: terraform_providers_lock
+        stages: [commit]
+        args:
+          - --args=-platform=darwin_amd64
+          - --args=-platform=linux_amd64
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.7.1
+    hooks:
+      - id: prettier
+        stages: [commit]
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.4.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@open-turo/commitlint-config-conventional"]
+  - repo: https://github.com/turo/pre-commit-hooks
+    rev: v3.4.1
+    hooks:
+      - id: go-fmt
+      - id: golangci-lint
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.23
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0 # or specific git tag
+    hooks:
+      - id: shellcheck
+      - id: shfmt
+```

--- a/hooks/outputs-in-outputs-files/check
+++ b/hooks/outputs-in-outputs-files/check
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+check_files() {
+	has_error=0
+	for file in "$@"; do
+
+		# ignore files that start with outputs.
+		if [[ "$file" == */outputs.*tf ]]; then
+			echo "outputs file ok: $file"
+		# grep the file to see if it has a line that start with 'outputs "'
+		elif grep -q "^output \"" "$file"; then
+			echo "ERROR: $file MUST not contain outputs"
+			has_error=1
+		fi
+	done
+	return $has_error
+}
+
+if ! check_files "$@"; then
+	echo "outputs defined in files that do not match our naming convention: 'outputs[.grouping].tf'"
+	echo "See: https://open-turo.github.io/standards-terraform/modules/outputs/"
+fi
+
+exit $has_error

--- a/hooks/outputs-in-outputs-files/fixtures/bad.tf
+++ b/hooks/outputs-in-outputs-files/fixtures/bad.tf
@@ -1,0 +1,4 @@
+output "should_fail" {
+  description = "This should fail because it isn't in file that starts with variables.tf"
+  value = "should fail"
+}

--- a/hooks/outputs-in-outputs-files/fixtures/outputs.function.tf
+++ b/hooks/outputs-in-outputs-files/fixtures/outputs.function.tf
@@ -1,0 +1,4 @@
+output "test" {
+  description = "Simple output"
+  value = "good value"
+}

--- a/hooks/outputs-in-outputs-files/test
+++ b/hooks/outputs-in-outputs-files/test
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# get the directory of the script
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "testing: $script_directory"
+
+echo "testing: check $script_directory/fixtures/outputs.function.tf"
+"$script_directory/check" "$script_directory/fixtures/outputs.function.tf"
+
+# check to see if the next file failed
+echo "testing: check $script_directory/fixtures/bad.tf"
+echo "         expecting error"
+if "$script_directory/check" "$script_directory/fixtures/bad.tf"; then
+	echo "ERROR: should have failed"
+	exit 1
+fi
+
+echo "testing: PASS"

--- a/hooks/vars-in-variables-files/check
+++ b/hooks/vars-in-variables-files/check
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+check_files() {
+	has_error=0
+	for file in "$@"; do
+
+		# grep the file to see if it has a line that start with 'variable "'
+		if [[ "$file" == */variables.*tf ]]; then
+			echo "variables file ok: $file"
+		elif grep -q "^variable \"" "$file"; then
+			echo "ERROR: $file MUST not contain variables"
+			has_error=1
+		fi
+	done
+	return $has_error
+}
+
+if ! check_files "$@"; then
+	echo "Variables defined in files that do not match our naming convention: 'variables[.grouping].tf'"
+	echo "See: https://open-turo.github.io/standards-terraform/modules/input-variables/"
+fi
+
+exit $has_error

--- a/hooks/vars-in-variables-files/fixtures/bad.tf
+++ b/hooks/vars-in-variables-files/fixtures/bad.tf
@@ -1,0 +1,4 @@
+variable "should_fail" {
+  default = "true"
+  description = "This should fail because it isn't in file that starts with variables.tf"
+}

--- a/hooks/vars-in-variables-files/fixtures/variables.function.tf
+++ b/hooks/vars-in-variables-files/fixtures/variables.function.tf
@@ -1,0 +1,4 @@
+variable "test" {
+  default = "test"
+  description = "Simple variable"
+}

--- a/hooks/vars-in-variables-files/test
+++ b/hooks/vars-in-variables-files/test
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+# get the directory of the script
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "testing: $script_directory"
+
+echo "testing: check $script_directory/fixtures/variables.function.tf"
+"$script_directory/check" "$script_directory/fixtures/variables.function.tf"
+
+# check to see if the next file failed
+echo "testing: check $script_directory/fixtures/bad.tf"
+echo "         expecting error"
+if "$script_directory/check" "$script_directory/fixtures/bad.tf"; then
+	echo "ERROR: should have failed"
+	exit 1
+fi
+
+echo "testing: PASS"

--- a/script/test
+++ b/script/test
@@ -2,4 +2,5 @@
 
 REPO_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)")"
 
-"$REPO_DIR/hooks/variables/test"
+"$REPO_DIR/hooks/outputs-in-outputs-files/test"
+"$REPO_DIR/hooks/vars-in-variables-files/test"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+REPO_DIR="$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)")"
+
+"$REPO_DIR/hooks/variables/test"


### PR DESCRIPTION
**Description**

This adds checks for variables and outputs standards.

The hooks work in other repos:
```
Ensure that all variables are defined in files that have the following name format: `variables[.grouping].tf`.......................Failed
- hook id: vars-in-variables-files
- exit code: 1

ERROR: modules/authorization/iam.tf MUST not contain variables
Variables defined in files that do not match our naming convention: 'variables[.grouping].tf'
See: https://open-turo.github.io/standards-terraform/modules/input-variables/
variables file ok: workspaces/developer-sandbox/variables.tf

Ensure that all outputs are defined in files that have the following name format: `outputs[.grouping].tf`...........................Failed
- hook id: outputs-in-outputs-files
- exit code: 1

ERROR: modules/common/main.tf MUST not contain outputs
outputs defined in files that do not match our naming convention: 'outputs[.grouping].tf'
See: https://open-turo.github.io/standards-terraform/modules/outputs/
ERROR: modules/common/subaccount_ids.tf MUST not contain outputs
outputs defined in files that do not match our naming convention: 'outputs[.grouping].tf'
See: https://open-turo.github.io/standards-terraform/modules/outputs/
ERROR: modules/common/shared.tf MUST not contain outputs
outputs defined in files that do not match our naming convention: 'outputs[.grouping].tf'
See: https://open-turo.github.io/standards-terraform/modules/outputs/
```


**Changes**

* fix(variables): pre-commit check to enforce variables in variables file
* fix(pre-commit): add check for outputs in non outputs files

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
