### PR TITLE
DEVOPS-9448: Update open-turo mkdocs standards-terraform for breaking changes doc template

### DIFF
--- a/docs/modules/breaking-changes.md
+++ b/docs/modules/breaking-changes.md
@@ -6,5 +6,7 @@ This is best implemented through deprecation first to add new/replacement functi
 now unused functionality.
 
 When creating a breaking change - you **MUST** include a markdown document in the `docs/breaking-changes` directory. It
-should be named `v<version>.md` where `<version>` is the new/breakign version. This document should explain the breaking
+should be named `v<version>.md` where `<version>` is the new/breaking version. This document should explain the breaking
 change and how to migrate to the new version.
+
+A template [here](templates/breaking-changes-doc-template.md), is a good starting point for your breaking changes markdown document.

--- a/templates/breaking-changes-doc-template.md
+++ b/templates/breaking-changes-doc-template.md
@@ -1,0 +1,28 @@
+# Upgrade from v[PREVIOUS].x to v[CURRENT].x
+
+- Brief description of current major version release scope
+
+## List of backwards incompatible changes
+
+- Removed input/output
+- Schema change for input/output
+- Provider version constraint change
+- Terraform version constraint change
+- Underlying major module version change
+- Any logic/behavior change
+
+## Additional changes
+
+- Added functionalities
+- Refactoring
+- Bug fixes
+- Documentation updates
+- Test updates
+
+## Upgrade migration
+
+- Elaborate on major functionality changes
+- Required and suggested prerequisites (backups, etc.)
+- Required and suggested state moves
+- Expected diff output (try to use `diff` format)
+- Example code


### PR DESCRIPTION
**Description**

Adding a template for breaking change markdown document.

This will help engineers to understand what needs to be included for a breaking change document and thereby providing a consistency across all the breaking change documentation

Fixes [#DEVOPS-9448](https://team-turo.atlassian.net//browse/DEVOPS-9448)

**Changes**

* feat(breaking-changes): adds template for breaking changes doc

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
