### PR TITLE
update terraform standards

### DIFF
--- a/docs/style/input-variables.md
+++ b/docs/style/input-variables.md
@@ -1,0 +1,25 @@
+# Input Variables
+
+If an input variable needs to be defined as null or emtpy:
+
+- prefer using a `nullable` variable with a default value of `null`
+- if a `nullable` variable is not possible, use a `string` variable with a default value of `""` and add an explanation why.
+
+Examples:
+
+```hcl
+variable "foo" {
+  type        = string
+  description = "This variable is a string that can be null"
+  default     = null
+}
+
+variable "bar" {
+  type        = string
+  description = "This variable is a string that can be empty, but not null"
+  nullable    = false
+
+  # Add an explanation why this variable is not nullable
+  default = ""
+}
+```

--- a/docs/style/naming.md
+++ b/docs/style/naming.md
@@ -1,6 +1,6 @@
 # Naming
 
-First - follow all the guidance in https://www.terraform-best-practices.com/naming
+First - follow all the guidance in [https://www.terraform-best-practices.com/naming](https://www.terraform-best-practices.com/naming)
 
 ## File names
 


### PR DESCRIPTION
**Description**

Following our review meeting, it was agreed that we should standardize 2 additional things:
- use of `this`/`main`.  This was already in the [best practices doc](https://www.terraform-best-practices.com/naming#resource-and-data-source-arguments) and says we should use `this`.
- nullable vs empty variables.  This is added in this PR.

**Changes**

* feat: add standard for nullable/empty input variables

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
