### PR TITLE
fix(ci): reference to mkdocs file was wrong

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
           key: ${{ github.sha }}
           path: .cache
       - name: Build site (_site directory name is used for Jekyll compatiblity)
-        run: mkdocs build --config-file ./mkdocs.yml --site-dir ./_site
+        run: mkdocs build --config-file ./mkdocs.yaml --site-dir ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
Release workflow was failing because of the `mkdocs` release step.