### PR TITLE
fix: regex for variables and outputs didn't work correctly

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: hooks/vars-in-variables-files/check
   language: script
   files: \.tf$
-  exclude: ^variables\..*\.tf$
+  exclude: ^variables[\.]{0,1}.*\.tf$
 
 - id: outputs-in-outputs-files
   name: "Ensure outputs are in `outputs[.grouping].tf`"
@@ -12,7 +12,7 @@
   entry: hooks/outputs-in-outputs-files/check
   language: script
   files: \.tf$
-  exclude: ^outputs\..*\.tf$
+  exclude: ^outputs[\.]{0,1}.*\.tf$
 
 - id: provider-pinned-versions
   name: "Ensures provider versions are pinned.`"

--- a/hooks/vars-in-variables-files/fixtures/variables.tf
+++ b/hooks/vars-in-variables-files/fixtures/variables.tf
@@ -1,0 +1,4 @@
+variable "test" {
+  default = "test"
+  description = "Simple variable"
+}

--- a/hooks/vars-in-variables-files/test
+++ b/hooks/vars-in-variables-files/test
@@ -5,6 +5,9 @@ script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "testing: $script_directory"
 
+echo "testing: check $script_directory/fixtures/variables.tf"
+"$script_directory/check" "$script_directory/fixtures/variables.tf"
+
 echo "testing: check $script_directory/fixtures/variables.function.tf"
 "$script_directory/check" "$script_directory/fixtures/variables.function.tf"
 


### PR DESCRIPTION
The variable and output hooks weren't working on the `variables.tf` and `outputs.tf` files of modules because they weren't ignored.