### PR TITLE
fix: remove escape sequence char to remove warning

### DIFF
--- a/hooks/provider-pinned-versions/required_providers.awk
+++ b/hooks/provider-pinned-versions/required_providers.awk
@@ -4,7 +4,7 @@ BEGIN {
     in_required_providers = 0;
     brace_count = 0;
     version_prefix_regex = ".*version[[:space:]]+=[[:space:]]+";
-    provider_prefix_regex = "[a-z_-]+[[:space:]]+=[[:space:]]+\{";
+    provider_prefix_regex = "[a-z_-]+[[:space:]]+=[[:space:]]+{";
     version_constraints_regex = "[!~><]+";
 }
 


### PR DESCRIPTION
Removing unnecessary escape character in AWK script so we don't see the following warning:

![image](https://github.com/user-attachments/assets/bbafd4f0-eef2-4341-b0d1-f128610360c0)
